### PR TITLE
Changes to automatic script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ libretro-database
 RetroArch
 libretro-db.sqlite
 libretrodb_tool.exe
+libretrodb_tool
 READMEOLD.md

--- a/automatic-sqlite-generation.sh
+++ b/automatic-sqlite-generation.sh
@@ -1,19 +1,31 @@
 #!/bin/bash
+#
+CWD=`pwd`
+
+build_libretrodb_tool() {
+  cd RetroArch/libretro-db
+  make clean
+  make all
+  cp ./libretrodb_tool $CWD
+  cd $CWD
+}
+
 if [ ! -d libretro-database ];then
-  git clone https://github.com/libretro/libretro-database
+  git clone --depth=1 https://github.com/libretro/libretro-database
 else
   cd libretro-database
   git pull
-  cd ..
+  cd $CWD
 fi
 if [ ! -d RetroArch ];then
-  git clone https://github.com/libretro/RetroArch
+  git clone --depth=1 https://github.com/libretro/RetroArch
 else
   cd RetroArch/libretro-db
   git pull
-  make clean
-  make all
-  cp ./libretrodb_tool ../..
-  cd ../..
+  cd $CWD
 fi
+
+build_libretrodb_tool
+unset CWD
+rm -f libretro-db.sqlite
 python3 libretro2sqlite.py


### PR DESCRIPTION
- Add linux binary to gitignore
- Shallow clone repos (bit quicker clone, and about 0.5GB less disk space requirement)
- Add `build_libretrodb_tool` function so there isn't a need to run the automatic script twice (once after the clone and another to build)